### PR TITLE
fixing optional field set to default

### DIFF
--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -662,11 +662,13 @@ impl Python {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         let python_field_name = python_property_aware_rename(&field.id.original);
         if field.ty.is_optional() || field.has_default {
+            let mut add_none_str: &str = "";
             if python_field_name == field.id.renamed{
-                python_type = format!("Optional[{}] = None", python_type);
-                self.module
-                    .add_import("typing".to_string(), "Optional".to_string());
-                }
+                add_none_str = " = None";
+            }
+            python_type = format!("Optional[{}]{}", python_type, add_none_str);
+            self.module
+                .add_import("typing".to_string(), "Optional".to_string());
         }
         let mut default = None;
         if field.has_default {

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -661,10 +661,12 @@ impl Python {
             .format_type(&field.ty, generic_types)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         let python_field_name = python_property_aware_rename(&field.id.original);
-        if field.ty.is_optional() || field.has_default && python_field_name == field.id.renamed {
-            python_type = format!("Optional[{}] = None", python_type);
-            self.module
-                .add_import("typing".to_string(), "Optional".to_string());
+        if field.ty.is_optional() || field.has_default {
+            if python_field_name == field.id.renamed{
+                python_type = format!("Optional[{}] = None", python_type);
+                self.module
+                    .add_import("typing".to_string(), "Optional".to_string());
+                }
         }
         let mut default = None;
         if field.has_default {

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -661,7 +661,7 @@ impl Python {
             .format_type(&field.ty, generic_types)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         let python_field_name = python_property_aware_rename(&field.id.original);
-        python_type = match python_field_name == field.id.renamed || field.ty.is_optional() || field.has_default{
+        python_type = match python_field_name == field.id.renamed{
             true => python_type,
             false => {
                 self.module


### PR DESCRIPTION
This PR updates the way that typeshare translates Optional fields in Python. Previously, an empty optional field would produce an error. Now, if the value of the Optional field is not specified, a default value of None will be assumed, and no errors occur.