### PR TITLE
Add Feature Flag for Python TS

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 
 [features]
 go = []
+python = []
 
 [dependencies]
 clap = { version = "3", features = ["cargo"] }

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -20,13 +20,13 @@ pub const ARG_FOLLOW_LINKS: &str = "follow-links";
 pub const ARG_TARGET_OS: &str = "target_os";
 
 #[cfg(all(feature = "go", feature = "python"))]
-const AVAILABLE_LANGUAGES: [&str; 7] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
+const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
 
 #[cfg(all(feature = "go", not(feature = "python")))]
-const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go"];
+const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
 
 #[cfg(all(feature = "python", not(feature = "go")))]
-const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "python"];
+const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "python"];
 
 #[cfg(not(any(feature = "go", feature = "python")))]
 const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -19,21 +19,10 @@ pub const ARG_OUTPUT_FOLDER: &str = "output-folder";
 pub const ARG_FOLLOW_LINKS: &str = "follow-links";
 pub const ARG_TARGET_OS: &str = "target_os";
 
-// #[cfg(all(feature = "go", feature = "python"))]
-// const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
-
-// #[cfg(all(feature = "go", not(feature = "python")))]
-// const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
-
-// #[cfg(all(feature = "python", not(feature = "go")))]
-// const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "python"];
-
-// #[cfg(not(any(feature = "go", feature = "python")))]
-// const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];
-
 /// Parse command line arguments.
 pub(crate) fn build_command() -> Command<'static> {
-    let languages: Vec<&str> = vec!["kotlin", "scala", "swift", "typescript"];
+    #[allow(unused_mut)] // As its thrown behind feature flag, the compiler thinks we are not mutating the vector
+    let mut languages: Vec<&str> = vec!["kotlin", "scala", "swift", "typescript"];
     #[cfg(feature = "go")]
     languages.push("go");
     #[cfg(feature = "python")]

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -19,11 +19,17 @@ pub const ARG_OUTPUT_FOLDER: &str = "output-folder";
 pub const ARG_FOLLOW_LINKS: &str = "follow-links";
 pub const ARG_TARGET_OS: &str = "target_os";
 
-#[cfg(feature = "go")]
-const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
+#[cfg(all(feature = "go", feature = "python"))]
+const AVAILABLE_LANGUAGES: [&str; 7] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
 
-#[cfg(not(feature = "go"))]
-const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "python"];
+#[cfg(all(feature = "go", not(feature = "python")))]
+const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go"];
+
+#[cfg(all(feature = "python", not(feature = "go")))]
+const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "python"];
+
+#[cfg(not(any(feature = "go", feature = "python")))]
+const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];
 
 /// Parse command line arguments.
 pub(crate) fn build_command() -> Command<'static> {

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -19,20 +19,26 @@ pub const ARG_OUTPUT_FOLDER: &str = "output-folder";
 pub const ARG_FOLLOW_LINKS: &str = "follow-links";
 pub const ARG_TARGET_OS: &str = "target_os";
 
-#[cfg(all(feature = "go", feature = "python"))]
-const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
+// #[cfg(all(feature = "go", feature = "python"))]
+// const AVAILABLE_LANGUAGES: [&str; 6] = ["kotlin", "scala", "swift", "typescript", "go", "python"];
 
-#[cfg(all(feature = "go", not(feature = "python")))]
-const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
+// #[cfg(all(feature = "go", not(feature = "python")))]
+// const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "go"];
 
-#[cfg(all(feature = "python", not(feature = "go")))]
-const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "python"];
+// #[cfg(all(feature = "python", not(feature = "go")))]
+// const AVAILABLE_LANGUAGES: [&str; 5] = ["kotlin", "scala", "swift", "typescript", "python"];
 
-#[cfg(not(any(feature = "go", feature = "python")))]
-const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];
+// #[cfg(not(any(feature = "go", feature = "python")))]
+// const AVAILABLE_LANGUAGES: [&str; 4] = ["kotlin", "scala", "swift", "typescript"];
 
 /// Parse command line arguments.
 pub(crate) fn build_command() -> Command<'static> {
+    let languages: Vec<&str> = vec!["kotlin", "scala", "swift", "typescript"];
+    #[cfg(feature = "go")]
+    languages.push("go");
+    #[cfg(feature = "python")]
+    languages.push("python");
+
     command!("typeshare")
         .version(VERSION)
         .args_conflicts_with_subcommands(true)
@@ -54,7 +60,7 @@ pub(crate) fn build_command() -> Command<'static> {
                 .long("lang")
                 .help("Language of generated types")
                 .takes_value(true)
-                .possible_values(AVAILABLE_LANGUAGES)
+                .possible_values(languages)
                 .required_unless(ARG_GENERATE_CONFIG),
         )
         .arg(

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -12,6 +12,7 @@ const DEFAULT_CONFIG_FILE_NAME: &str = "typeshare.toml";
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
 #[serde(default)]
+#[cfg(feature = "python")]
 pub struct PythonParams {
     pub type_mappings: HashMap<String, String>,
 }
@@ -69,6 +70,7 @@ pub(crate) struct Config {
     pub typescript: TypeScriptParams,
     pub kotlin: KotlinParams,
     pub scala: ScalaParams,
+    #[cfg(feature = "python")]
     pub python: PythonParams,
     #[cfg(feature = "go")]
     pub go: GoParams,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,9 @@ use rayon::iter::ParallelBridge;
 use std::collections::{BTreeMap, HashMap};
 #[cfg(feature = "go")]
 use typeshare_core::language::Go;
-use typeshare_core::language::{GenericConstraints, Python};
+#[cfg(feature = "python")]
+use typeshare_core::language::Python;
+use typeshare_core::language::GenericConstraints;
 use typeshare_core::{
     language::{CrateName, Kotlin, Language, Scala, SupportedLanguage, Swift, TypeScript},
     parser::ParsedData,
@@ -191,10 +193,15 @@ fn language(
         SupportedLanguage::Go => {
             panic!("go support is currently experimental and must be enabled as a feature flag for typeshare-cli")
         }
+        #[cfg(feature = "python")]
         SupportedLanguage::Python => Box::new(Python {
             type_mappings: config.python.type_mappings,
             ..Default::default()
         }),
+        #[cfg(not(feature = "python"))]
+        SupportedLanguage::Python => {
+            panic!("python support is currently experimental and must be enabled as a feature flag for typeshare-cli")
+        }
     }
 }
 


### PR DESCRIPTION
This PR will add a feature flag for using Python TS as this would be in beta and not in the stable TS versions.

This will allow users to run something like this to install Python TS:
`cargo install typeshare --features python`

How to test:
`cargo install --git https://github.com/hculea/typeshare --branch omar/239/add-feature-flag --features python`
and you should be able to use python typeshare to typeshare any file.
Then try removing python and you will get this error.
```
error: "python" isn't a valid value for '--lang <TYPE>'
        [possible values: kotlin, scala, swift, typescript, go]

For more information try --help
```

you can also try different options like 
`cargo install --git https://github.com/hculea/typeshare --branch omar/239/add-feature-flag --features "python go"` to get both go and python, etc