### PR TITLE
Fix tuple variant generation

### DIFF
--- a/core/data/tests/anonymous_struct_with_rename/output.py
+++ b/core/data/tests/anonymous_struct_with_rename/output.py
@@ -45,7 +45,7 @@ class AnonymousStructWithRenameTypes(str, Enum):
 class AnonymousStructWithRename(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AnonymousStructWithRenameTypes
-    content: Union[AnonymousStructWithRenameList, AnonymousStructWithRenameLongFieldNames, AnonymousStructWithRenameKebabCase]
+    content: Union[AnonymousStructWithRenameKebabCase, AnonymousStructWithRenameList, AnonymousStructWithRenameLongFieldNames]
 
 
     @classmethod

--- a/core/data/tests/can_apply_prefix_correctly/output.py
+++ b/core/data/tests/can_apply_prefix_correctly/output.py
@@ -23,7 +23,7 @@ class AdvancedColorsTypes(str, Enum):
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     t: AdvancedColorsTypes
-    c: Union[str, int, List[int], ItemDetailsFieldValue, List[ItemDetailsFieldValue], Dict[str, ItemDetailsFieldValue]]
+    c: Union[Dict[str, ItemDetailsFieldValue], ItemDetailsFieldValue, List[ItemDetailsFieldValue], List[int], int, str]
 
 
     @classmethod

--- a/core/data/tests/can_apply_prefix_correctly/output.py
+++ b/core/data/tests/can_apply_prefix_correctly/output.py
@@ -20,32 +20,14 @@ class AdvancedColorsTypes(str, Enum):
     ARRAY_REALLY_COOL_TYPE = "ArrayReallyCoolType"
     DICTIONARY_REALLY_COOL_TYPE = "DictionaryReallyCoolType"
 
-class AdvancedColorsString(BaseModel):
-    c: str
-
-class AdvancedColorsNumber(BaseModel):
-    c: int
-
-class AdvancedColorsNumberArray(BaseModel):
-    c: List[int]
-
-class AdvancedColorsReallyCoolType(BaseModel):
-    c: ItemDetailsFieldValue
-
-class AdvancedColorsArrayReallyCoolType(BaseModel):
-    c: List[ItemDetailsFieldValue]
-
-class AdvancedColorsDictionaryReallyCoolType(BaseModel):
-    c: Dict[str, ItemDetailsFieldValue]
-
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     t: AdvancedColorsTypes
-    c: Union[AdvancedColorsString, AdvancedColorsNumber, AdvancedColorsNumberArray, AdvancedColorsReallyCoolType, AdvancedColorsArrayReallyCoolType, AdvancedColorsDictionaryReallyCoolType]
+    c: Union[str, int, List[int], ItemDetailsFieldValue, List[ItemDetailsFieldValue], Dict[str, ItemDetailsFieldValue]]
 
 
     @classmethod
-    def new_advanced_colors_string(cls, c : AdvancedColorsString):
+    def new_advanced_colors_string(cls, c : str):
         return cls(
             t=AdvancedColorsTypes.STRING,
             c=c
@@ -53,7 +35,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number(cls, c : AdvancedColorsNumber):
+    def new_advanced_colors_number(cls, c : int):
         return cls(
             t=AdvancedColorsTypes.NUMBER,
             c=c
@@ -61,7 +43,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number_array(cls, c : AdvancedColorsNumberArray):
+    def new_advanced_colors_number_array(cls, c : List[int]):
         return cls(
             t=AdvancedColorsTypes.NUMBER_ARRAY,
             c=c
@@ -69,7 +51,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_really_cool_type(cls, c : AdvancedColorsReallyCoolType):
+    def new_advanced_colors_really_cool_type(cls, c : ItemDetailsFieldValue):
         return cls(
             t=AdvancedColorsTypes.REALLY_COOL_TYPE,
             c=c
@@ -77,7 +59,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_array_really_cool_type(cls, c : AdvancedColorsArrayReallyCoolType):
+    def new_advanced_colors_array_really_cool_type(cls, c : List[ItemDetailsFieldValue]):
         return cls(
             t=AdvancedColorsTypes.ARRAY_REALLY_COOL_TYPE,
             c=c
@@ -85,7 +67,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_dictionary_really_cool_type(cls, c : AdvancedColorsDictionaryReallyCoolType):
+    def new_advanced_colors_dictionary_really_cool_type(cls, c : Dict[str, ItemDetailsFieldValue]):
         return cls(
             t=AdvancedColorsTypes.DICTIONARY_REALLY_COOL_TYPE,
             c=c

--- a/core/data/tests/can_generate_algebraic_enum/output.py
+++ b/core/data/tests/can_generate_algebraic_enum/output.py
@@ -24,7 +24,7 @@ class AdvancedColorsTypes(str, Enum):
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColorsTypes
-    content: Union[str, int, int, List[int], ItemDetailsFieldValue]
+    content: Union[ItemDetailsFieldValue, List[int], int, str]
 
 
     @classmethod
@@ -74,7 +74,7 @@ class AdvancedColors2Types(str, Enum):
 class AdvancedColors2(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColors2Types
-    content: Union[str, int, List[int], ItemDetailsFieldValue]
+    content: Union[ItemDetailsFieldValue, List[int], int, str]
 
 
     @classmethod

--- a/core/data/tests/can_generate_algebraic_enum/output.py
+++ b/core/data/tests/can_generate_algebraic_enum/output.py
@@ -21,29 +21,14 @@ class AdvancedColorsTypes(str, Enum):
     NUMBER_ARRAY = "NumberArray"
     REALLY_COOL_TYPE = "ReallyCoolType"
 
-class AdvancedColorsString(BaseModel):
-    content: str
-
-class AdvancedColorsNumber(BaseModel):
-    content: int
-
-class AdvancedColorsUnsignedNumber(BaseModel):
-    content: int
-
-class AdvancedColorsNumberArray(BaseModel):
-    content: List[int]
-
-class AdvancedColorsReallyCoolType(BaseModel):
-    content: ItemDetailsFieldValue
-
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColorsTypes
-    content: Union[AdvancedColorsString, AdvancedColorsNumber, AdvancedColorsUnsignedNumber, AdvancedColorsNumberArray, AdvancedColorsReallyCoolType]
+    content: Union[str, int, int, List[int], ItemDetailsFieldValue]
 
 
     @classmethod
-    def new_advanced_colors_string(cls, content : AdvancedColorsString):
+    def new_advanced_colors_string(cls, content : str):
         return cls(
             type=AdvancedColorsTypes.STRING,
             content=content
@@ -51,7 +36,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number(cls, content : AdvancedColorsNumber):
+    def new_advanced_colors_number(cls, content : int):
         return cls(
             type=AdvancedColorsTypes.NUMBER,
             content=content
@@ -59,7 +44,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_unsigned_number(cls, content : AdvancedColorsUnsignedNumber):
+    def new_advanced_colors_unsigned_number(cls, content : int):
         return cls(
             type=AdvancedColorsTypes.UNSIGNED_NUMBER,
             content=content
@@ -67,7 +52,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number_array(cls, content : AdvancedColorsNumberArray):
+    def new_advanced_colors_number_array(cls, content : List[int]):
         return cls(
             type=AdvancedColorsTypes.NUMBER_ARRAY,
             content=content
@@ -75,7 +60,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_really_cool_type(cls, content : AdvancedColorsReallyCoolType):
+    def new_advanced_colors_really_cool_type(cls, content : ItemDetailsFieldValue):
         return cls(
             type=AdvancedColorsTypes.REALLY_COOL_TYPE,
             content=content
@@ -86,26 +71,14 @@ class AdvancedColors2Types(str, Enum):
     NUMBER_ARRAY = "number-array"
     REALLY_COOL_TYPE = "really-cool-type"
 
-class AdvancedColors2String(BaseModel):
-    content: str
-
-class AdvancedColors2Number(BaseModel):
-    content: int
-
-class AdvancedColors2NumberArray(BaseModel):
-    content: List[int]
-
-class AdvancedColors2ReallyCoolType(BaseModel):
-    content: ItemDetailsFieldValue
-
 class AdvancedColors2(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColors2Types
-    content: Union[AdvancedColors2String, AdvancedColors2Number, AdvancedColors2NumberArray, AdvancedColors2ReallyCoolType]
+    content: Union[str, int, List[int], ItemDetailsFieldValue]
 
 
     @classmethod
-    def new_advanced_colors_2_string(cls, content : AdvancedColors2String):
+    def new_advanced_colors_2_string(cls, content : str):
         return cls(
             type=AdvancedColors2Types.STRING,
             content=content
@@ -113,7 +86,7 @@ class AdvancedColors2(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_2_number(cls, content : AdvancedColors2Number):
+    def new_advanced_colors_2_number(cls, content : int):
         return cls(
             type=AdvancedColors2Types.NUMBER,
             content=content
@@ -121,7 +94,7 @@ class AdvancedColors2(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_2_number_array(cls, content : AdvancedColors2NumberArray):
+    def new_advanced_colors_2_number_array(cls, content : List[int]):
         return cls(
             type=AdvancedColors2Types.NUMBER_ARRAY,
             content=content
@@ -129,7 +102,7 @@ class AdvancedColors2(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_2_really_cool_type(cls, content : AdvancedColors2ReallyCoolType):
+    def new_advanced_colors_2_really_cool_type(cls, content : ItemDetailsFieldValue):
         return cls(
             type=AdvancedColors2Types.REALLY_COOL_TYPE,
             content=content

--- a/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.py
+++ b/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.py
@@ -16,7 +16,7 @@ class SomeEnumTypes(str, Enum):
 class SomeEnum(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: SomeEnumTypes
-    content: Union[int, None]
+    content: Union[None, int]
 
 
     @classmethod

--- a/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.py
+++ b/core/data/tests/can_generate_algebraic_enum_with_skipped_variants/output.py
@@ -13,13 +13,10 @@ class SomeEnumTypes(str, Enum):
     C = "C"
 
 
-class SomeEnumC(BaseModel):
-    content: int
-
 class SomeEnum(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: SomeEnumTypes
-    content: Union[SomeEnumC, None]
+    content: Union[int, None]
 
 
     @classmethod
@@ -31,7 +28,7 @@ class SomeEnum(BaseModel):
 
 
     @classmethod
-    def new_some_enum_c(cls, content : SomeEnumC):
+    def new_some_enum_c(cls, content : int):
         return cls(
             type=SomeEnumTypes.C,
             content=content

--- a/core/data/tests/can_generate_anonymous_struct_with_skipped_fields/output.py
+++ b/core/data/tests/can_generate_anonymous_struct_with_skipped_fields/output.py
@@ -35,7 +35,7 @@ class AutofilledByTypes(str, Enum):
 class AutofilledBy(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AutofilledByTypes
-    content: Union[AutofilledByUs, AutofilledBySomethingElse]
+    content: Union[AutofilledBySomethingElse, AutofilledByUs]
 
 
     @classmethod

--- a/core/data/tests/can_generate_empty_algebraic_enum/output.py
+++ b/core/data/tests/can_generate_empty_algebraic_enum/output.py
@@ -15,18 +15,15 @@ class AddressTypes(str, Enum):
     FIXED_ADDRESS = "FixedAddress"
     NO_FIXED_ADDRESS = "NoFixedAddress"
 
-class AddressFixedAddress(BaseModel):
-    content: AddressDetails
-
 
 class Address(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AddressTypes
-    content: Union[AddressFixedAddress, None]
+    content: Union[AddressDetails, None]
 
 
     @classmethod
-    def new_address_fixed_address(cls, content : AddressFixedAddress):
+    def new_address_fixed_address(cls, content : AddressDetails):
         return cls(
             type=AddressTypes.FIXED_ADDRESS,
             content=content

--- a/core/data/tests/can_handle_anonymous_struct/output.py
+++ b/core/data/tests/can_handle_anonymous_struct/output.py
@@ -80,17 +80,11 @@ class EnumWithManyVariantsTypes(str, Enum):
     ANOTHER_ANON_VARIANT = "AnotherAnonVariant"
 
 
-class EnumWithManyVariantsTupleVariantString(BaseModel):
-    content: str
-
-class EnumWithManyVariantsTupleVariantInt(BaseModel):
-    content: int
-
 
 class EnumWithManyVariants(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: EnumWithManyVariantsTypes
-    content: Union[EnumWithManyVariantsTupleVariantString, EnumWithManyVariantsAnonVariant, EnumWithManyVariantsTupleVariantInt, EnumWithManyVariantsAnotherAnonVariant, None]
+    content: Union[str, EnumWithManyVariantsAnonVariant, int, EnumWithManyVariantsAnotherAnonVariant, None]
 
 
     @classmethod
@@ -102,7 +96,7 @@ class EnumWithManyVariants(BaseModel):
 
 
     @classmethod
-    def new_enum_with_many_variants_tuple_variant_string(cls, content : EnumWithManyVariantsTupleVariantString):
+    def new_enum_with_many_variants_tuple_variant_string(cls, content : str):
         return cls(
             type=EnumWithManyVariantsTypes.TUPLE_VARIANT_STRING,
             content=content
@@ -118,7 +112,7 @@ class EnumWithManyVariants(BaseModel):
 
 
     @classmethod
-    def new_enum_with_many_variants_tuple_variant_int(cls, content : EnumWithManyVariantsTupleVariantInt):
+    def new_enum_with_many_variants_tuple_variant_int(cls, content : int):
         return cls(
             type=EnumWithManyVariantsTypes.TUPLE_VARIANT_INT,
             content=content

--- a/core/data/tests/can_handle_anonymous_struct/output.py
+++ b/core/data/tests/can_handle_anonymous_struct/output.py
@@ -39,7 +39,7 @@ class AutofilledByTypes(str, Enum):
 class AutofilledBy(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AutofilledByTypes
-    content: Union[AutofilledByUs, AutofilledBySomethingElse]
+    content: Union[AutofilledBySomethingElse, AutofilledByUs]
 
 
     @classmethod
@@ -84,7 +84,7 @@ class EnumWithManyVariantsTypes(str, Enum):
 class EnumWithManyVariants(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: EnumWithManyVariantsTypes
-    content: Union[str, EnumWithManyVariantsAnonVariant, int, EnumWithManyVariantsAnotherAnonVariant, None]
+    content: Union[EnumWithManyVariantsAnonVariant, EnumWithManyVariantsAnotherAnonVariant, None, int, str]
 
 
     @classmethod

--- a/core/data/tests/can_handle_unit_type/output.py
+++ b/core/data/tests/can_handle_unit_type/output.py
@@ -19,17 +19,14 @@ class StructHasVoidType(BaseModel):
 class EnumHasVoidTypeTypes(str, Enum):
     HAS_A_UNIT = "hasAUnit"
 
-class EnumHasVoidTypeHasAUnit(BaseModel):
-    content: None
-
 class EnumHasVoidType(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: EnumHasVoidTypeTypes
-    content: EnumHasVoidTypeHasAUnit
+    content: None
 
 
     @classmethod
-    def new_enum_has_void_type_has_a_unit(cls, content : EnumHasVoidTypeHasAUnit):
+    def new_enum_has_void_type_has_a_unit(cls, content : None):
         return cls(
             type=EnumHasVoidTypeTypes.HAS_A_UNIT,
             content=content

--- a/core/data/tests/excluded_by_target_os/output.py
+++ b/core/data/tests/excluded_by_target_os/output.py
@@ -62,7 +62,7 @@ class TestEnumTypes(str, Enum):
 class TestEnum(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: TestEnumTypes
-    content: Union[TestEnumVariant7, TestEnumVariant9, None]
+    content: Union[None, TestEnumVariant7, TestEnumVariant9]
 
 
     @classmethod

--- a/core/data/tests/recursive_enum_decorator/output.py
+++ b/core/data/tests/recursive_enum_decorator/output.py
@@ -30,7 +30,7 @@ class MoreOptionsTypes(str, Enum):
 class MoreOptions(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: MoreOptionsTypes
-    content: Union[bool, MoreOptionsExactly, MoreOptionsBuilt]
+    content: Union[MoreOptionsBuilt, MoreOptionsExactly, bool]
 
 
     @classmethod
@@ -63,7 +63,7 @@ class OptionsTypes(str, Enum):
 class Options(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: OptionsTypes
-    content: Union[bool, str, Options]
+    content: Union[Options, bool, str]
 
 
     @classmethod

--- a/core/data/tests/recursive_enum_decorator/output.py
+++ b/core/data/tests/recursive_enum_decorator/output.py
@@ -27,17 +27,14 @@ class MoreOptionsTypes(str, Enum):
     EXACTLY = "exactly"
     BUILT = "built"
 
-class MoreOptionsNews(BaseModel):
-    content: bool
-
 class MoreOptions(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: MoreOptionsTypes
-    content: Union[MoreOptionsNews, MoreOptionsExactly, MoreOptionsBuilt]
+    content: Union[bool, MoreOptionsExactly, MoreOptionsBuilt]
 
 
     @classmethod
-    def new_more_options_news(cls, content : MoreOptionsNews):
+    def new_more_options_news(cls, content : bool):
         return cls(
             type=MoreOptionsTypes.NEWS,
             content=content
@@ -63,23 +60,14 @@ class OptionsTypes(str, Enum):
     BANANA = "banana"
     VERMONT = "vermont"
 
-class OptionsRed(BaseModel):
-    content: bool
-
-class OptionsBanana(BaseModel):
-    content: str
-
-class OptionsVermont(BaseModel):
-    content: Options
-
 class Options(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: OptionsTypes
-    content: Union[OptionsRed, OptionsBanana, OptionsVermont]
+    content: Union[bool, str, Options]
 
 
     @classmethod
-    def new_options_red(cls, content : OptionsRed):
+    def new_options_red(cls, content : bool):
         return cls(
             type=OptionsTypes.RED,
             content=content
@@ -87,7 +75,7 @@ class Options(BaseModel):
 
 
     @classmethod
-    def new_options_banana(cls, content : OptionsBanana):
+    def new_options_banana(cls, content : str):
         return cls(
             type=OptionsTypes.BANANA,
             content=content
@@ -95,7 +83,7 @@ class Options(BaseModel):
 
 
     @classmethod
-    def new_options_vermont(cls, content : OptionsVermont):
+    def new_options_vermont(cls, content : Options):
         return cls(
             type=OptionsTypes.VERMONT,
             content=content

--- a/core/data/tests/serialize_anonymous_field_as/output.py
+++ b/core/data/tests/serialize_anonymous_field_as/output.py
@@ -15,7 +15,7 @@ class SomeEnumTypes(str, Enum):
 class SomeEnum(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: SomeEnumTypes
-    content: Union[str, int]
+    content: Union[int, str]
 
 
     @classmethod

--- a/core/data/tests/serialize_anonymous_field_as/output.py
+++ b/core/data/tests/serialize_anonymous_field_as/output.py
@@ -12,20 +12,14 @@ class SomeEnumTypes(str, Enum):
     CONTEXT = "Context"
     OTHER = "Other"
 
-class SomeEnumContext(BaseModel):
-    content: str
-
-class SomeEnumOther(BaseModel):
-    content: int
-
 class SomeEnum(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: SomeEnumTypes
-    content: Union[SomeEnumContext, SomeEnumOther]
+    content: Union[str, int]
 
 
     @classmethod
-    def new_some_enum_context(cls, content : SomeEnumContext):
+    def new_some_enum_context(cls, content : str):
         return cls(
             type=SomeEnumTypes.CONTEXT,
             content=content
@@ -33,7 +27,7 @@ class SomeEnum(BaseModel):
 
 
     @classmethod
-    def new_some_enum_other(cls, content : SomeEnumOther):
+    def new_some_enum_other(cls, content : int):
         return cls(
             type=SomeEnumTypes.OTHER,
             content=content

--- a/core/data/tests/smart_pointers/output.py
+++ b/core/data/tests/smart_pointers/output.py
@@ -63,13 +63,10 @@ class BoxyColorsTypes(str, Enum):
 
 
 
-class BoxyColorsGreen(BaseModel):
-    content: str
-
 class BoxyColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: BoxyColorsTypes
-    content: Union[BoxyColorsGreen, None]
+    content: Union[str, None]
 
 
     @classmethod
@@ -89,7 +86,7 @@ class BoxyColors(BaseModel):
 
 
     @classmethod
-    def new_boxy_colors_green(cls, content : BoxyColorsGreen):
+    def new_boxy_colors_green(cls, content : str):
         return cls(
             type=BoxyColorsTypes.GREEN,
             content=content

--- a/core/data/tests/smart_pointers/output.py
+++ b/core/data/tests/smart_pointers/output.py
@@ -66,7 +66,7 @@ class BoxyColorsTypes(str, Enum):
 class BoxyColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: BoxyColorsTypes
-    content: Union[str, None]
+    content: Union[None, str]
 
 
     @classmethod

--- a/core/data/tests/test_algebraic_enum_case_name_support/output.py
+++ b/core/data/tests/test_algebraic_enum_case_name_support/output.py
@@ -17,26 +17,14 @@ class AdvancedColorsTypes(str, Enum):
     NUMBER_ARRAY = "number-array"
     REALLY_COOL_TYPE = "reallyCoolType"
 
-class AdvancedColorsString(BaseModel):
-    content: str
-
-class AdvancedColorsNumber(BaseModel):
-    content: int
-
-class AdvancedColorsNumberArray(BaseModel):
-    content: List[int]
-
-class AdvancedColorsReallyCoolType(BaseModel):
-    content: ItemDetailsFieldValue
-
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColorsTypes
-    content: Union[AdvancedColorsString, AdvancedColorsNumber, AdvancedColorsNumberArray, AdvancedColorsReallyCoolType]
+    content: Union[str, int, List[int], ItemDetailsFieldValue]
 
 
     @classmethod
-    def new_advanced_colors_string(cls, content : AdvancedColorsString):
+    def new_advanced_colors_string(cls, content : str):
         return cls(
             type=AdvancedColorsTypes.STRING,
             content=content
@@ -44,7 +32,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number(cls, content : AdvancedColorsNumber):
+    def new_advanced_colors_number(cls, content : int):
         return cls(
             type=AdvancedColorsTypes.NUMBER,
             content=content
@@ -52,7 +40,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_number_array(cls, content : AdvancedColorsNumberArray):
+    def new_advanced_colors_number_array(cls, content : List[int]):
         return cls(
             type=AdvancedColorsTypes.NUMBER_ARRAY,
             content=content
@@ -60,7 +48,7 @@ class AdvancedColors(BaseModel):
 
 
     @classmethod
-    def new_advanced_colors_really_cool_type(cls, content : AdvancedColorsReallyCoolType):
+    def new_advanced_colors_really_cool_type(cls, content : ItemDetailsFieldValue):
         return cls(
             type=AdvancedColorsTypes.REALLY_COOL_TYPE,
             content=content

--- a/core/data/tests/test_algebraic_enum_case_name_support/output.py
+++ b/core/data/tests/test_algebraic_enum_case_name_support/output.py
@@ -20,7 +20,7 @@ class AdvancedColorsTypes(str, Enum):
 class AdvancedColors(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
     type: AdvancedColorsTypes
-    content: Union[str, int, List[int], ItemDetailsFieldValue]
+    content: Union[ItemDetailsFieldValue, List[int], int, str]
 
 
     @classmethod

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -638,7 +638,7 @@ impl Python {
                 } => {
                     let tuple_name = self
                         .format_type(ty, shared.generic_types.as_slice())
-                        .unwrap();
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                     variant_class_names.insert(tuple_name.clone());
                     Self::gen_tuple_variant_constructor(
                         &mut variant_constructors,

--- a/core/src/language/python.rs
+++ b/core/src/language/python.rs
@@ -8,7 +8,7 @@ use crate::{
     rust_types::{RustEnum, RustEnumVariant, RustField, RustStruct, RustTypeAlias},
 };
 use once_cell::sync::Lazy;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::hash::Hash;
 use std::{collections::HashMap, io::Write};
 
@@ -612,7 +612,7 @@ impl Python {
         )?;
         writeln!(w)?;
 
-        let mut variant_class_names = vec![];
+        let mut variant_class_names = BTreeSet::new();
         let mut variant_constructors = vec![];
         let mut contains_unit_variant = false;
         // write each of the enum variant as a class:
@@ -639,7 +639,7 @@ impl Python {
                     let tuple_name = self
                         .format_type(ty, shared.generic_types.as_slice())
                         .unwrap();
-                    variant_class_names.push(tuple_name.clone());
+                    variant_class_names.insert(tuple_name.clone());
                     Self::gen_tuple_variant_constructor(
                         &mut variant_constructors,
                         variant_shared,
@@ -653,7 +653,7 @@ impl Python {
                     fields,
                     shared: variant_shared,
                 } => {
-                    variant_class_names.push(variant_class_name.clone());
+                    variant_class_names.insert(variant_class_name.clone());
                     // writing is taken care of by write_types_for_anonymous_structs in write_enum
                     // we just need to push to the variant_constructors
                     self.gen_anon_struct_variant_constructor(
@@ -669,8 +669,10 @@ impl Python {
             }
         }
         if contains_unit_variant {
-            variant_class_names.push("None".to_string());
+            variant_class_names.insert("None".to_string());
         }
+
+        let variant_class_names = variant_class_names.into_iter().collect::<Vec<String>>();
 
         // finally, write the enum class itself consists of a type and a union of all the enum variants
 


### PR DESCRIPTION
This PR fixes tuple variant generation by not generating a new class for each tuple variant. 

Before this PR, each tuple variant is treated like an anonymous class even though the type information is already given. This resulted in an unnecessary layer of indirection.

For example:

```rs
#[typeshare]
#[serde(tag = "t", content = "c")]
enum RustEnum {
    A(String),
}
```

will generate the following:

```py
class RustEnumTypes(str, Enum):
    A = "A"

class RustEnum(BaseModel):
    model_config = ConfigDict(use_enum_values=True)
    t: RustEnumTypes
    c: str


    @classmethod
    def new_rust_enum_a(cls, c : str):
        return cls(
            t=RustEnumTypes.A,
            c=c
        )

```

Instead of the old (incorrect) generation:
```py
class RustEnumTypes(str, Enum):
    A = "A"

class RustEnumA(BaseModel):
    c: str

class RustEnum(BaseModel):
    model_config = ConfigDict(use_enum_values=True)
    t: RustEnumTypes
    c: RustEnumA


    @classmethod
    def new_rust_enum_a(cls, c : RustEnumA):
        return cls(
            t=RustEnumTypes.A,
            c=c
        )
```
